### PR TITLE
Remove 'hugo-integration' branch from GitHub Actions workflow for gh-…

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - hugo-integration
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
…pages to simplify branch management.